### PR TITLE
Configuration protection option

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ ownership of the stored data in `/syncthing` and `$CONFIG_DIR`.
 You can pass these environment variables to configure the client:
 
 - `CONFIG_DIR` (default: `/syncthing/config`)
+- `CONFIG_OVERWRITE` (default: `true`)
 - `GUI_ADDRESS` (default: `[::]:8384`)
 - `GUI_ENABLED` (default: `true`)
 - `GUI_TLS` (default: `false`)

--- a/start.sh
+++ b/start.sh
@@ -44,6 +44,8 @@ CONFIG_FILE=$CONFIG_DIR/config.xml
 : ${GUI_TLS:='false'}
 : ${GUI_USERNAME:=''}
 : ${GUI_PASSWORD_PLAIN:=''}
+: ${CONFIG_OVERWRITE:=true}
+
 if [ -z "$GUI_PASSWORD_BCRYPT" ] && [ -n "$GUI_PASSWORD_PLAIN" ]; then
     echo "Calculating password hash..."
     GUI_PASSWORD_BCRYPT=$(htpasswd -bnB -C12 foo ${GUI_PASSWORD_PLAIN} | cut -f2 -d:)
@@ -65,23 +67,27 @@ if [ ! -f $CONFIG_FILE ]; then
     syncthing -generate=$CONFIG_DIR
     config_del "/configuration/folder"
     config_set "options/startBrowser" "false"
+	CONFIG_OVERWRITE=true
 fi
 
 # update config.xml according to environment variables
-config_set "gui/address" $GUI_ADDRESS
-config_set "gui/@enabled" $GUI_ENABLED
-config_set "gui/@tls" $GUI_TLS
-config_set "gui/user" $GUI_USERNAME
-config_set "gui/password" $GUI_PASSWORD_BCRYPT
+if $CONFIG_OVERWRITE ; then
+	echo "Configuration overwriting.."
+	config_set "gui/address" $GUI_ADDRESS
+	config_set "gui/@enabled" $GUI_ENABLED
+	config_set "gui/@tls" $GUI_TLS
+	config_set "gui/user" $GUI_USERNAME
+	config_set "gui/password" $GUI_PASSWORD_BCRYPT
 
-if config_count "gui/user"; then
-    config_set "gui/insecureAdminAccess" "true"
-else
-    config_del "gui/insecureAdminAccess"
-fi
+	if config_count "gui/user"; then
+		config_set "gui/insecureAdminAccess" "true"
+	else
+		config_del "gui/insecureAdminAccess"
+	fi
 
-if [ -n "$GUI_APIKEY" ]; then
-    config_set "gui/apikey" $GUI_APIKEY
+	if [ -n "$GUI_APIKEY" ]; then
+		config_set "gui/apikey" $GUI_APIKEY
+	fi
 fi
 
 unset GUI_PASSWORD_PLAIN


### PR DESCRIPTION
Ciao,
with this pull a new environment variable is added: CONFIG_OVERWRITE
by default this variable is set to "true" in order to keep the backcompatibility with existing app behavior.

When it is set to false, the environment variables are ignored and they are not written back in the configuration file.

Hope, it's fine for you as well.

Regards,
Salvo