### PR TITLE
Updated SYNCTHING_VERSION to v0.14.44.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ VOLUME /syncthing/config /syncthing/data
 CMD /start.sh
 ADD start.sh /
 
-ENV SYNCTHING_VERSION=0.14.43
+ENV SYNCTHING_VERSION=0.14.44
 
 RUN apk upgrade --no-cache \
  && apk add --no-cache apr apr-util ca-certificates su-exec xmlstarlet \


### PR DESCRIPTION
A simple change of `SYNCTHING_VERSION` was enough to update your docker image to the most recent Syncthing version.