### PR TITLE
Update dockerfile to add tzdata alphabetically

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ADD start.sh /
 ENV SYNCTHING_VERSION=0.14.49
 
 RUN apk upgrade --no-cache \
- && apk add --no-cache apr apr-util ca-certificates su-exec xmlstarlet \
+ && apk add --no-cache apr apr-util ca-certificates su-exec tzdata xmlstarlet \
  && apk add --no-cache --virtual .build-deps apache2-utils curl tar \
  && cd /usr/bin \
  && cp htpasswd /tmp \


### PR DESCRIPTION
Add tzdata so we can use the environment variable TZ to set a local timezone. Alpine lacks the package tzdata. Also bump version.

For more information about the "issue" with the Alpine images:
gliderlabs/docker-alpine#136

Now in improved alphabetical order!